### PR TITLE
fix: clear expiration token key together with refresh token

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -274,6 +274,8 @@ class ApiClient {
    */
   public async setRefreshToken(token: string | null): Promise<void> {
     if (!token) {
+      this.setAccessTokenExp(undefined);
+
       await this.storage.deleteItem(ApiClient.REFRESH_TOKEN_KEY);
 
       return;


### PR DESCRIPTION
When clearing out the refresh token from local storage we want to clear the expiration value of access token aswell